### PR TITLE
feat: adding charts/sabnzbd

### DIFF
--- a/charts/sabnzbd/.helmignore
+++ b/charts/sabnzbd/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/sabnzbd/Chart.yaml
+++ b/charts/sabnzbd/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: sabnzbd
+description: A Helm chart for Kubernetes to install sabnzbd
+appVersion: "4.5.3"
+version: 1.0.0
+kubeVersion: ">=1.19.0-0"
+home: https://someadmin.com/helm-charts/sabnzbd
+icon: https://someadmin.com/images/someadmin-logo.png
+sources:
+  - https://github.com/someadmin-org/helm-charts
+  - https://sabnzbd.org/
+maintainers:
+  - name: someadmin
+    email: contact@someadmin.com
+type: application
+keywords:
+  - sabnzbd
+  - nzb
+  - usenet
+  - download
+  - someadmin
+annotations:
+  "artifacthub.io/operator": "false"
+  "artifacthub.io/licenses": "MIT"
+  "artifacthub.io/links.logo": https://someadmin.com/images/someadmin-logo.png
+  "artifacthub.io/links.home": https://someadmin.com/helm-charts/sabnzbd
+  "artifacthub.io/links.maintainers": https://someadmin.com/helm-charts
+  "artifacthub.io/links.source": "https://github.com/someadmin-org/helm-charts/tree/main/charts/sabnzbd"

--- a/charts/sabnzbd/README.md
+++ b/charts/sabnzbd/README.md
@@ -1,0 +1,268 @@
+# SABnzbd Helm Chart
+
+A Helm chart for deploying SABnzbd, a free and easy binary newsreader, on Kubernetes.
+
+## Overview
+
+SABnzbd is an Open Source Binary Newsreader written in Python. It's totally free, incredibly easy to use, and works practically everywhere. SABnzbd makes Usenet as simple and streamlined as possible by automating everything we can.
+
+This Helm chart deploys SABnzbd on a Kubernetes cluster using the Helm package manager.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.0+
+- A persistent volume provisioner (if using persistent storage)
+
+## Installation
+
+### Add the Helm Repository
+
+```bash
+helm repo add someadmin https://someadmin-org.github.io/helm-charts
+helm repo update
+```
+
+### Install the Chart
+
+```bash
+helm install sabnzbd someadmin/sabnzbd
+```
+
+To install with custom values:
+
+```bash
+helm install sabnzbd someadmin/sabnzbd -f values.yaml
+```
+
+## Configuration
+
+The following table lists the configurable parameters and their default values:
+
+### Image Configuration
+
+| Parameter          | Description              | Default                       |
+| ------------------ | ------------------------ | ----------------------------- |
+| `image.repository` | SABnzbd image repository | `lscr.io/linuxserver/sabnzbd` |
+| `image.pullPolicy` | Image pull policy        | `IfNotPresent`                |
+| `image.tag`        | Image tag                | `latest`                      |
+| `imagePullSecrets` | Image pull secrets       | `[]`                          |
+
+### Service Account
+
+| Parameter                    | Description                                | Default |
+| ---------------------------- | ------------------------------------------ | ------- |
+| `serviceAccount.create`      | Create a service account                   | `false` |
+| `serviceAccount.automount`   | Auto-mount service account API credentials | `true`  |
+| `serviceAccount.annotations` | Service account annotations                | `{}`    |
+| `serviceAccount.name`        | Service account name                       | `""`    |
+
+### Pod Configuration
+
+| Parameter            | Description                | Default |
+| -------------------- | -------------------------- | ------- |
+| `podAnnotations`     | Pod annotations            | `{}`    |
+| `podLabels`          | Pod labels                 | `{}`    |
+| `podSecurityContext` | Pod security context       | `{}`    |
+| `securityContext`    | Container security context | `{}`    |
+
+### Service Configuration
+
+| Parameter             | Description         | Default     |
+| --------------------- | ------------------- | ----------- |
+| `service.type`        | Service type        | `ClusterIP` |
+| `service.port`        | Service port        | `8080`      |
+| `service.annotations` | Service annotations | `{}`        |
+| `service.labels`      | Service labels      | `{}`        |
+
+### Ingress Configuration
+
+| Parameter             | Description                 | Default         |
+| --------------------- | --------------------------- | --------------- |
+| `ingress.enabled`     | Enable ingress              | `false`         |
+| `ingress.className`   | Ingress class name          | `""`            |
+| `ingress.annotations` | Ingress annotations         | `{}`            |
+| `ingress.hosts`       | Ingress hosts configuration | See values.yaml |
+| `ingress.tls`         | Ingress TLS configuration   | `[]`            |
+
+### Health Checks
+
+| Parameter        | Description                   | Default |
+| ---------------- | ----------------------------- | ------- |
+| `livenessProbe`  | Liveness probe configuration  | `{}`    |
+| `readinessProbe` | Readiness probe configuration | `{}`    |
+
+### Resources
+
+| Parameter   | Description                         | Default |
+| ----------- | ----------------------------------- | ------- |
+| `resources` | CPU/Memory resource requests/limits | `{}`    |
+
+### Environment Variables
+
+| Parameter | Description                                              | Default         |
+| --------- | -------------------------------------------------------- | --------------- |
+| `env`     | Additional environment variables                         | See values.yaml |
+| `envFrom` | Additional environment variables from ConfigMaps/Secrets | `[]`            |
+
+### Storage
+
+| Parameter                 | Description                    | Default             |
+| ------------------------- | ------------------------------ | ------------------- |
+| `persistence.accessModes` | Persistent volume access modes | `["ReadWriteOnce"]` |
+| `persistence.size`        | Persistent volume size         | `1Gi`               |
+| `persistence.annotations` | Persistent volume annotations  | `{}`                |
+| `persistence.labels`      | Persistent volume labels       | `{}`                |
+
+### Additional Volumes
+
+| Parameter      | Description              | Default |
+| -------------- | ------------------------ | ------- |
+| `volumes`      | Additional volumes       | `[]`    |
+| `volumeMounts` | Additional volume mounts | `[]`    |
+
+### Scheduling
+
+| Parameter      | Description   | Default |
+| -------------- | ------------- | ------- |
+| `nodeSelector` | Node selector | `{}`    |
+| `tolerations`  | Tolerations   | `[]`    |
+| `affinity`     | Affinity      | `{}`    |
+
+## Usage Examples
+
+### Basic Installation
+
+```bash
+helm install sabnzbd someadmin/sabnzbd
+```
+
+### Installation with Ingress
+
+```yaml
+# values.yaml
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+  hosts:
+    - host: sabnzbd.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: sabnzbd-tls
+      hosts:
+        - sabnzbd.example.com
+```
+
+```bash
+helm install sabnzbd someadmin/sabnzbd -f values.yaml
+```
+
+### Installation with Custom Storage
+
+```yaml
+# values.yaml
+persistence:
+  size: 50Gi
+  storageClass: "fast-ssd"
+
+resources:
+  requests:
+    memory: "512Mi"
+    cpu: "200m"
+  limits:
+    memory: "2Gi"
+    cpu: "1000m"
+```
+
+### Installation with Custom Environment
+
+```yaml
+# values.yaml
+env:
+  - name: PUID
+    value: "1001"
+  - name: PGID
+    value: "1001"
+  - name: TZ
+    value: "America/New_York"
+  - name: UMASK_SET
+    value: "022"
+```
+
+## Accessing SABnzbd
+
+After installation, you can access SABnzbd using one of the following methods:
+
+### Port Forward (for testing)
+
+```bash
+kubectl port-forward service/sabnzbd 8080:8080
+```
+
+Then open your browser to `http://localhost:8080`
+
+### Ingress (recommended for production)
+
+Configure the ingress as shown in the examples above, then access via your configured hostname.
+
+### LoadBalancer or NodePort
+
+Set the service type to `LoadBalancer` or `NodePort` and access via the external IP or node IP.
+
+## Upgrading
+
+To upgrade the chart:
+
+```bash
+helm upgrade sabnzbd someadmin/sabnzbd
+```
+
+## Uninstalling
+
+To uninstall the chart:
+
+```bash
+helm uninstall my-sabnzbd
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Pod not starting**: Check if the persistent volume is available and properly configured
+2. **Permission issues**: Ensure PUID and PGID environment variables are set correctly
+3. **Ingress not working**: Verify ingress controller is installed and configured properly
+
+### Debug Commands
+
+```bash
+# Check pod status
+kubectl get pods -l app.kubernetes.io/name=sabnzbd
+
+# Check pod logs
+kubectl logs -l app.kubernetes.io/name=sabnzbd
+
+# Check persistent volume claims
+kubectl get pvc
+
+# Describe pod for detailed information
+kubectl describe pod <pod-name>
+```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+This chart is licensed under the MIT License. See the LICENSE file for details.
+
+## Links
+
+- [SABnzbd Official Website](https://sabnzbd.org/)
+- [LinuxServer SABnzbd Docker Image](https://docs.linuxserver.io/images/docker-sabnzbd)
+- [Chart Repository](https://github.com/someadmin-org/helm-charts)

--- a/charts/sabnzbd/templates/NOTES.txt
+++ b/charts/sabnzbd/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "sabnzbd.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "sabnzbd.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "sabnzbd.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "sabnzbd.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/sabnzbd/templates/_helpers.tpl
+++ b/charts/sabnzbd/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sabnzbd.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sabnzbd.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sabnzbd.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "sabnzbd.labels" -}}
+helm.sh/chart: {{ include "sabnzbd.chart" . }}
+{{ include "sabnzbd.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "sabnzbd.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sabnzbd.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sabnzbd.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "sabnzbd.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/sabnzbd/templates/deployment.yaml
+++ b/charts/sabnzbd/templates/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sabnzbd.fullname" . }}
+  labels:
+    {{- include "sabnzbd.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "sabnzbd.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "sabnzbd.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "sabnzbd.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          envFrom:
+            {{- toYaml .Values.envFrom | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /config
+          {{- with .Values.volumeMounts }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: {{ include "sabnzbd.fullname" . }}-config
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/sabnzbd/templates/ingress.yaml
+++ b/charts/sabnzbd/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "sabnzbd.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "sabnzbd.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/sabnzbd/templates/pvc.yaml
+++ b/charts/sabnzbd/templates/pvc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{- toYaml .Values.persistence.annotations | nindent 4 }}
+{{- end }}
+  labels:
+    {{- include "sabnzbd.labels" . | nindent 4 }}
+    {{- with .Values.persistence.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "sabnzbd.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+{{- toYaml .Values.persistence.accessModes | nindent 4 }}
+{{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . }}
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}

--- a/charts/sabnzbd/templates/service.yaml
+++ b/charts/sabnzbd/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sabnzbd.fullname" . }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{- toYaml .Values.service.annotations | nindent 4 }}
+{{- end }}
+  labels:
+    {{- include "sabnzbd.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "sabnzbd.selectorLabels" . | nindent 4 }}

--- a/charts/sabnzbd/templates/serviceaccount.yaml
+++ b/charts/sabnzbd/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sabnzbd.serviceAccountName" . }}
+  labels:
+    {{- include "sabnzbd.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/sabnzbd/values.yaml
+++ b/charts/sabnzbd/values.yaml
@@ -1,0 +1,143 @@
+# Default values for sabnzbd.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: lscr.io/linuxserver/sabnzbd
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 8080
+  annotations: {}
+  labels: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+livenessProbe:
+  {}
+  # httpGet:
+  #   path: /login/
+  #   port: http
+  # initialDelaySeconds: 90
+  # timeoutSeconds: 5
+  # periodSeconds: 10
+  # successThreshold: 1
+  # failureThreshold: 5
+
+readinessProbe:
+  {}
+  # httpGet:
+  #   path: /login/
+  #   port: http
+  # initialDelaySeconds: 30
+  # timeoutSeconds: 5
+  # periodSeconds: 10
+  # successThreshold: 1
+  # failureThreshold: 5
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Add additional environment variables to the container
+env:
+  - name: PUID
+    value: "1000"
+  - name: PGID
+    value: "1000"
+  - name: TZ
+    value: "Etc/UTC"
+# - name: UMASK_SET
+#   value: "022" #optional
+
+# Add additional environment variables to the container
+envFrom: []
+# - configMapRef:
+#     name: my-config-map
+# - secretRef:
+#     name: my-secret
+
+persistence:
+  # storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi
+  annotations: {}
+  labels: {}
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This pull request introduces a new Helm chart for deploying SABnzbd on Kubernetes. It provides all the necessary files and templates to support a flexible, production-ready deployment, including configuration options for service, ingress, persistent storage, environment variables, and more. The chart is well-documented and follows Helm best practices for templating and customization.

**Helm Chart Structure and Metadata**

* Added `Chart.yaml` to define chart metadata, version, maintainers, and annotations for artifact repositories.
* Added `.helmignore` to exclude unnecessary files from chart packaging.

**Deployment and Kubernetes Resources**

* Implemented templated manifests for `Deployment`, `Service`, `Ingress`, `PersistentVolumeClaim`, and optional `ServiceAccount`, supporting customization via Helm values. [[1]](diffhunk://#diff-5cdad7beab3d0789d17597318fb6834b7d6f23f51f4faefafb00c133f8bf4c3aR1-R79) [[2]](diffhunk://#diff-cee7362cee0871ff7ac459233caa2539ff8aeba9e722137416d5e14f89f90b52R1-R22) [[3]](diffhunk://#diff-84754ab1865a12fff5dfaafe88cc916641e235c17c8660853c57107d456705ccR1-R61) [[4]](diffhunk://#diff-2b8b99462c16cd05573826a14af3ca7e5f17f84e8f33c445aa8ebffbcf62587fR1-R23) [[5]](diffhunk://#diff-abc2ec4604691ea9e2ce02a515c30ab27b17a262a026811dfdf734cc63e4b7e5R1-R13)
* Centralized label, name, and service account logic in `_helpers.tpl` for consistency across resources.

**Configuration and Customization**

* Added a comprehensive `values.yaml` with default settings and comments to guide users in customizing image, service, ingress, probes, resources, environment variables, storage, and scheduling.

**Documentation and Usage**

* Provided a detailed `README.md` with overview, installation steps, configuration tables, usage examples, troubleshooting, and links to upstream resources.
* Added a templated `NOTES.txt` to display access instructions after installation, adapting to service type and ingress configuration.