### PR TITLE
Configure GitHub CI Workflow/Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: Lint, test and release Helm charts
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: latest
+
+      - name: Lint
+        shell: bash
+        run: |
+          set -e
+          for d in charts/*; do
+            [[ -f "$d/Chart.yaml" ]] || continue
+            echo "==> helm lint $d"
+            helm lint "$d"
+          done
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: latest
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+
+      - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1
+
+      - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
   packages: write
 
+env:
+  REGISTRY: ghcr.io/someadmin-org/helm-charts
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -80,8 +83,25 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Run chart-releaser
+      - name: Publish charts to Helm repo
         uses: helm/chart-releaser-action@v1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: "true"
+
+      - name: Publish charts to Helm registry
+        shell: bash
+        run: |
+          set -e
+          shopt -s nullglob
+          for tgz in dist/*.tgz; do
+            name="$(basename "$tgz" | sed -E 's/(.*)-([0-9].*)\.tgz/\1/')"
+            ver="$(basename "$tgz" | sed -E 's/(.*)-([0-9].*)\.tgz/\2/')"
+            repo="oci://${REGISTRY,,}/$name"
+            echo "==> $name:$ver"
+            if helm show chart "$repo" --version "$ver" >/dev/null 2>&1; then
+              echo "   already exists, skipping"
+            else
+              helm push "$tgz" "oci://${REGISTRY,,}"
+            fi
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,14 @@ jobs:
         run: |
           set -e
           shopt -s nullglob
+
+          mkdir -p dist
+          for d in charts/*; do
+            [[ -f "$d/Chart.yaml" ]] || continue
+            echo "==> helm package $d"
+            helm package "$d" -d dist
+          done
+
           for tgz in dist/*.tgz; do
             name="$(basename "$tgz" | sed -E 's/(.*)-([0-9].*)\.tgz/\1/')"
             ver="$(basename "$tgz" | sed -E 's/(.*)-([0-9].*)\.tgz/\2/')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for continuous integration and delivery of Helm charts. The workflow automates linting, testing, and releasing Helm charts to both a Helm repository and an OCI registry.

**CI/CD workflow for Helm charts:**

* Added `.github/workflows/ci.yml` to define jobs for linting, testing, and releasing Helm charts on pull requests and pushes.

**Linting and testing improvements:**

* Configured jobs to lint all charts in the `charts/` directory using `helm lint` and run chart-testing for changed charts, including installation in a Kubernetes kind cluster.

**Automated release process:**

* Implemented steps to package and publish charts to a Helm repo via `helm/chart-releaser-action@v1` and push charts to an OCI registry, skipping existing versions.